### PR TITLE
Added footer to template

### DIFF
--- a/app/views/layouts/_calendar.njk
+++ b/app/views/layouts/_calendar.njk
@@ -74,3 +74,21 @@
   </div>
 
 {% endblock %}
+
+
+{% block footer %}
+
+<footer class="govuk-footer" role="contentinfo">
+<div class="govuk-width-container">
+  <div class="govuk-footer__container">
+    <p class="govuk-footer__text">
+
+  This is not a real government service - it's for training purposes.
+    <p class="govuk-footer__text">
+      Built using the <a href="https://prototype-kit.service.gov.uk/" class="govuk-link">GOV.UK Prototype Kit</a>.
+        </p>
+      <p>To contribute <a href="https://github.com/Lori-T/accessibility-advent-calendar.git" class="govuk-link">visit the GitHub repo.</a>
+  </div>
+</div>
+</footer>
+{% endblock %}

--- a/app/views/layouts/layout.html
+++ b/app/views/layouts/layout.html
@@ -58,7 +58,7 @@
 		  <p class="govuk-footer__text">
         Built using the <a href="https://prototype-kit.service.gov.uk/" class="govuk-link">GOV.UK Prototype Kit</a>.
 		      </p>
-			  <p>To contribute <a href="https://github.com/Lori-T/accessibility-advent-calendar.git" class govuk-link">visit the GitHub repo.</a>
+			  <p>To contribute <a href="https://github.com/Lori-T/accessibility-advent-calendar.git" class="govuk-link">visit the GitHub repo.</a>
     </div>
 	</div>
   </footer>


### PR DESCRIPTION
Brought footer from initial version into template


<img width="1157" alt="footer with note that this is for training and with links to the repository" src="https://github.com/user-attachments/assets/3cc41f68-78a9-401b-9177-564993b84c25">
