### PR TITLE
Tweaks to the home page

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -2,7 +2,8 @@
 {% extends "layouts/_calendar.njk" %}
 {% set hideBackLink = true %}
 {% set fullWidth = true %}
-{% set pageTitle = serviceName %}
+{% set largeTitle = true %}
+{% set pageTitle = "25 days of digital accessibility tips" %}
 
 {% block calendar %}
 
@@ -14,7 +15,7 @@
     {% for day in range(1, 26) %}
     {% if day <= currentDay %}
       <a href="/advent-calendar/day-{{ day }}" class="calendar-day govuk-link">
-        {{ day }}
+        Day {{ day }}
       </a>
     {% else %}
     <p class="calendar-day calendar-day-disabled">Opens soon</p>

--- a/app/views/layouts/_calendar.njk
+++ b/app/views/layouts/_calendar.njk
@@ -46,7 +46,7 @@
   <div class="govuk-grid-row">
     <div class="{% if fullWidth %}govuk-grid-column-full{% else %}govuk-grid-column-two-thirds{% endif %}">
 
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-{{"xl govuk-!-margin-bottom-2" if largeTitle else "l" }}">
         {{pageTitle | default("Set this page title with 'pageTitle'") }}
       </h1>
 


### PR DESCRIPTION
Added:

- better title
- bigger title with better margins
- 'Door' to open doors

![home page with title '25 days of digital accessibility tips'](https://github.com/user-attachments/assets/94593614-55b4-4636-94c7-3a3b318aeb40)
