### PR TITLE
Added correct image path

### DIFF
--- a/app/views/advent-calendar/day-3.html
+++ b/app/views/advent-calendar/day-3.html
@@ -17,7 +17,7 @@
   Approximately 1 in 4 people (24%) in the UK have a disability or long-term impairment. These stats do not include unreported disabilities, neurodiversity (such as Autism or ADHD), temporary impairments (for example, a person with an arm injury) or situational impairments (for example, a new parent holding a baby).
 </p>
 
-<img src="https://devblogs.microsoft.com/devops/wp-content/uploads/sites/6/2022/06/Figure-05.png" class="responsive-image" alt="A line drawing of people to show the difference in types of disability. Permanent disability is a person with one arm. Temporary disability is a person with an arm injury and their arm is in a sling. Situational disability is a new parent holding a baby">
+<img src="{{asset_path}}images/disabilitytypes.jpg" class="responsive-image" alt="A line drawing of people to show the difference in types of disability. Permanent disability is a person with one arm. Temporary disability is a person with an arm injury and their arm is in a sling. Situational disability is a new parent holding a baby">
 
 <h2 class="govuk-heading-m">Describing disability</h2>
 


### PR DESCRIPTION
To add images:

- add image to app/assets/images 
- use the path `<img src="{{asset_path}}images/FILE.FILETPE" />` - this will point to the place that the kit creates for images (/public/)

Important things
* `{{asset_path}}` does not need a / before or after as it does it automatically

example 

```
<img src="{{asset_path}}images/disabilitytypes.jpg" class="responsive-image" alt="A line drawing of people to show the difference in types of disability. Permanent disability is a person with one arm. Temporary disability is a person with an arm injury and their arm is in a sling. Situational disability is a new parent holding a baby">
```
Is populated as

```
<img src="/public/images/disabilitytypes.jpg" class="responsive-image" alt="A line drawing of people to show the difference in types of disability. Permanent disability is a person with one arm. Temporary disability is a person with an arm injury and their arm is in a sling. Situational disability is a new parent holding a baby">
```

